### PR TITLE
Trying to solve issues on travis by bumping build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --offline --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
conda installing regions for python 2.7 and numpy 1.9 raises a ValueError, while pip installing it works. Hopefully rebuilding the package resolves the issue.